### PR TITLE
Abort connection reason

### DIFF
--- a/examples/ios/FLiOS/FLiOSModel.swift
+++ b/examples/ios/FLiOS/FLiOSModel.swift
@@ -164,7 +164,7 @@ public class FLiOSModel: ObservableObject {
     
     public func abortFederatedLearning() {
         print("aborting federated learning")
-        self.flwrGRPC?.abortGRPCConnection {
+        self.flwrGRPC?.abortGRPCConnection(reasonDisconnect: .powerDisconnected) {
             DispatchQueue.main.async {
                 self.federatedServerStatus = .completed(info: "Federated learning aborted")
                 self.flwrGRPC = nil

--- a/src/swift/flwr/Sources/Flower/Common/Typing.swift
+++ b/src/swift/flwr/Sources/Flower/Common/Typing.swift
@@ -39,6 +39,27 @@ public enum Code: Equatable {
     }
 }
 
+public enum ReasonDisconnect {
+    typealias RawValue = Int
+    case unknown // = 0
+    case reconnect // = 1
+    case powerDisconnected // = 2
+    case wifiUnavailable // = 3
+    case ack // = 4
+    case UNRECOGNIZED(Int)
+
+    var rawValue: Int {
+      switch self {
+      case .unknown: return 0
+      case .reconnect: return 1
+      case .powerDisconnected: return 2
+      case .wifiUnavailable: return 3
+      case .ack: return 4
+      case .UNRECOGNIZED(let i): return i
+      }
+    }
+}
+
 public struct Scalar: Equatable {
     public var bool: Bool?
     public var bytes: Data?

--- a/src/swift/flwr/Sources/Flower/GRPC/FlwrGRPC.swift
+++ b/src/swift/flwr/Sources/Flower/GRPC/FlwrGRPC.swift
@@ -101,9 +101,10 @@ public class FlwrGRPC {
         }
     }
     
-    public func abortGRPCConnection(completion: @escaping () -> Void) {
+    public func abortGRPCConnection(reasonDisconnect: ReasonDisconnect, completion: @escaping () -> Void) {
         var disconnect = Flwr_Proto_ClientMessage.DisconnectRes()
-        disconnect.reason = .powerDisconnected
+        var reasonDisconnectProto = Flwr_Proto_Reason(rawValue: reasonDisconnect.rawValue)
+        disconnect.reason = reasonDisconnectProto!
         var clientMessage = Flwr_Proto_ClientMessage()
         clientMessage.disconnectRes = disconnect
         

--- a/src/swift/flwr/Sources/Flower/GRPC/FlwrGRPC.swift
+++ b/src/swift/flwr/Sources/Flower/GRPC/FlwrGRPC.swift
@@ -103,8 +103,9 @@ public class FlwrGRPC {
     
     public func abortGRPCConnection(reasonDisconnect: ReasonDisconnect, completion: @escaping () -> Void) {
         var disconnect = Flwr_Proto_ClientMessage.DisconnectRes()
-        var reasonDisconnectProto = Flwr_Proto_Reason(rawValue: reasonDisconnect.rawValue)
-        disconnect.reason = reasonDisconnectProto!
+        let reasonDisconnectProto = Flwr_Proto_Reason(rawValue: reasonDisconnect.rawValue)
+        
+        disconnect.reason = reasonDisconnectProto ?? .unknown
         var clientMessage = Flwr_Proto_ClientMessage()
         clientMessage.disconnectRes = disconnect
         

--- a/src/swift/flwr/Tests/FlowerTests/FlowerTests.swift
+++ b/src/swift/flwr/Tests/FlowerTests/FlowerTests.swift
@@ -223,4 +223,22 @@ final class FlowerTests: XCTestCase {
         XCTExpectFailure("Working on a fix for this problem.")
         XCTAssertEqual(scalar, result)
     }
+    
+    func testDisconnectReasonTransformation() throws {
+        let reasonUnkownProto = Flwr_Proto_Reason.unknown.rawValue
+        let reasonUnkown = ReasonDisconnect.unknown.rawValue
+        XCTAssertEqual(reasonUnkownProto, reasonUnkown)
+        let reasonPowerProto = Flwr_Proto_Reason.powerDisconnected.rawValue
+        let reasonPower = ReasonDisconnect.powerDisconnected.rawValue
+        XCTAssertEqual(reasonPowerProto, reasonPower)
+        let reasonReconnectProto = Flwr_Proto_Reason.reconnect.rawValue
+        let reasonReconnect = ReasonDisconnect.reconnect.rawValue
+        XCTAssertEqual(reasonReconnectProto, reasonReconnect)
+        let reasonAckProto = Flwr_Proto_Reason.ack.rawValue
+        let reasonAck = ReasonDisconnect.ack.rawValue
+        XCTAssertEqual(reasonAckProto, reasonAck)
+        let reasonWifiUnavailableProto = Flwr_Proto_Reason.wifiUnavailable.rawValue
+        let reasonWifiUnavailable = ReasonDisconnect.wifiUnavailable.rawValue
+        XCTAssertEqual(reasonWifiUnavailableProto, reasonWifiUnavailable)
+    }
 }


### PR DESCRIPTION
The client can specify the reason for disconnection. Implementation-wise, the PR includes:

- Providing a public enum (`ReasonDisconnect`) for the client to select the reason for disconnecting.
- Conversion of the public enum into the `Flwr_Proto_Reason` enumeration.
- Implement a test case, s.t. Align `Flwr_Proto_Reason` and `ReasonDisconnect`.